### PR TITLE
docs: document build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ export CGO_ENABLED=1
 export CGO_CFLAGS="-I$(PWD)/libjq/include"
 export CGO_LDFLAGS="-L$(PWD)/libjq/lib"
 
-build-libjq:
-	./scripts/build-libjq-go.sh 
+libjq/include/jq.h:
+	./scripts/build-libjq-go.sh
+
+build-libjq: libjq/include/jq.h scripts/build-libjq-go.sh
+
 test: local-libjq
 	go test ./...
 build:

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,13 @@
 all: test
 .SILENT:local-libjq
 PWD=$(shell pwd)
-export CGO_ENABLED=1
-export CGO_CFLAGS="-I$(PWD)/libjq/include"
-export CGO_LDFLAGS="-L$(PWD)/libjq/lib"
 
 libjq/include/jq.h:
 	./scripts/build-libjq-go.sh
 
 build-libjq: libjq/include/jq.h scripts/build-libjq-go.sh
 
-test: local-libjq
-	go test ./...
+test: build-libjq
+	CGO_ENABLED=1 CGO_CFLAGS="-I$(PWD)/libjq/include" CGO_LDFLAGS="-L$(PWD)/libjq/lib" go test ./...
 build:
-	go build -a -installsuffix cgo y2c.go
+	CGO_ENABLED=1 CGO_CFLAGS="-I$(PWD)/libjq/include" CGO_LDFLAGS="-L$(PWD)/libjq/lib" go build -a -installsuffix cgo y2c.go

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # yaml2confluence
 A CLI tool to manage Confluence content using YAML and Mustache template.
+
+## Initial Setup
+
+1. Ensure `autoreconf` is installed and available:
+    - MacOS
+      ```sh
+      which autoreconf || brew install autoconf
+      which aclocal || brew install automake
+      ```


### PR DESCRIPTION
ran into errors running the build-libjq make
target because I was missing these two toolchain
dependencies; documenting them so I don't forget